### PR TITLE
Update healthcheck.sh to be executable

### DIFF
--- a/Omada Beta/Dockerfile
+++ b/Omada Beta/Dockerfile
@@ -13,7 +13,7 @@ ARG ARCH=${TARGETARCH:-${BUILD_ARCH:-}}
 
 # install version (major.minor only); OMADA_URL set in install.sh
 ARG INSTALL_VER="5.9"
-RUN chmod +x install.sh
+RUN chmod +x /install.sh /healthcheck.sh
 
 # install omada controller (instructions taken from install.sh)
 RUN /install.sh && rm /install.sh 

--- a/Omada Stable/Dockerfile
+++ b/Omada Stable/Dockerfile
@@ -11,7 +11,7 @@ ARG ARCH=arm64
 
 COPY install.sh healthcheck.sh /
 
-RUN chmod +x /install.sh
+RUN chmod +x /install.sh /healthcheck.sh
 
 # install omada controller (instructions taken from install.sh); then create a user & group and set the appropriate file system permissions
 RUN /install.sh && rm /install.sh
@@ -21,6 +21,6 @@ RUN chmod +x entrypoint.sh
 
 WORKDIR /opt/tplink/EAPController/lib
 EXPOSE 8088 8043 8843 27001/udp 27002 29810/udp 29811 29812 29813 29814
-HEALTHCHECK --start-period=5m --retries=6 CMD /healthcheck.sh
+HEALTHCHECK --start-period=5m CMD /healthcheck.sh
 ENTRYPOINT ["/entrypoint.sh"]
 CMD ["/usr/bin/java","-server","-Xms128m","-Xmx1024m","-XX:MaxHeapFreeRatio=60","-XX:MinHeapFreeRatio=30","-XX:+HeapDumpOnOutOfMemoryError","-XX:HeapDumpPath=/opt/tplink/EAPController/logs/java_heapdump.hprof","-Djava.awt.headless=true","-cp","/opt/tplink/EAPController/lib/*::/opt/tplink/EAPController/properties:","com.tplink.smb.omada.starter.OmadaLinuxMain"]

--- a/Omada Stable/Dockerfile
+++ b/Omada Stable/Dockerfile
@@ -21,6 +21,6 @@ RUN chmod +x entrypoint.sh
 
 WORKDIR /opt/tplink/EAPController/lib
 EXPOSE 8088 8043 8843 27001/udp 27002 29810/udp 29811 29812 29813 29814
-HEALTHCHECK --start-period=5m CMD /healthcheck.sh
+HEALTHCHECK --start-period=5m CMD ['/bin/sh', '/healthcheck.sh']
 ENTRYPOINT ["/entrypoint.sh"]
 CMD ["/usr/bin/java","-server","-Xms128m","-Xmx1024m","-XX:MaxHeapFreeRatio=60","-XX:MinHeapFreeRatio=30","-XX:+HeapDumpOnOutOfMemoryError","-XX:HeapDumpPath=/opt/tplink/EAPController/logs/java_heapdump.hprof","-Djava.awt.headless=true","-cp","/opt/tplink/EAPController/lib/*::/opt/tplink/EAPController/properties:","com.tplink.smb.omada.starter.OmadaLinuxMain"]

--- a/Omada Stable/Dockerfile
+++ b/Omada Stable/Dockerfile
@@ -21,6 +21,6 @@ RUN chmod +x entrypoint.sh
 
 WORKDIR /opt/tplink/EAPController/lib
 EXPOSE 8088 8043 8843 27001/udp 27002 29810/udp 29811 29812 29813 29814
-HEALTHCHECK --start-period=5m CMD ['/bin/sh', '/healthcheck.sh']
+HEALTHCHECK --start-period=5m CMD /healthcheck.sh
 ENTRYPOINT ["/entrypoint.sh"]
 CMD ["/usr/bin/java","-server","-Xms128m","-Xmx1024m","-XX:MaxHeapFreeRatio=60","-XX:MinHeapFreeRatio=30","-XX:+HeapDumpOnOutOfMemoryError","-XX:HeapDumpPath=/opt/tplink/EAPController/logs/java_heapdump.hprof","-Djava.awt.headless=true","-cp","/opt/tplink/EAPController/lib/*::/opt/tplink/EAPController/properties:","com.tplink.smb.omada.starter.OmadaLinuxMain"]

--- a/Omada Stable/Dockerfile
+++ b/Omada Stable/Dockerfile
@@ -21,6 +21,6 @@ RUN chmod +x entrypoint.sh
 
 WORKDIR /opt/tplink/EAPController/lib
 EXPOSE 8088 8043 8843 27001/udp 27002 29810/udp 29811 29812 29813 29814
-HEALTHCHECK --start-period=5m CMD /healthcheck.sh
+HEALTHCHECK --start-period=5m --retries=6 CMD /healthcheck.sh
 ENTRYPOINT ["/entrypoint.sh"]
 CMD ["/usr/bin/java","-server","-Xms128m","-Xmx1024m","-XX:MaxHeapFreeRatio=60","-XX:MinHeapFreeRatio=30","-XX:+HeapDumpOnOutOfMemoryError","-XX:HeapDumpPath=/opt/tplink/EAPController/logs/java_heapdump.hprof","-Djava.awt.headless=true","-cp","/opt/tplink/EAPController/lib/*::/opt/tplink/EAPController/properties:","com.tplink.smb.omada.starter.OmadaLinuxMain"]

--- a/repository.json
+++ b/repository.json
@@ -1,5 +1,5 @@
 {
     "name": "Home Assistant Omada",
-    "url": "https://github.com/nathanielks/home-assistant-omada",
-    "maintainer": "nathanielks"
+    "url": "https://github.com/jkunczik/home-assistant-omada",
+    "maintainer": "DraTrav"
 }

--- a/repository.json
+++ b/repository.json
@@ -1,5 +1,5 @@
 {
     "name": "Home Assistant Omada",
-    "url": "https://github.com/jkunczik/home-assistant-omada",
-    "maintainer": "DraTrav"
+    "url": "https://github.com/nathanielks/home-assistant-omada",
+    "maintainer": "nathanielks"
 }


### PR DESCRIPTION
Fixes https://github.com/jkunczik/home-assistant-omada/issues/10.

Docker healthchecks are failing because `/healthcheck.sh` is not executable. This updates the file to be executable after being copied into the image.