### PR TITLE
Add Home Assistant certificate compatibility

### DIFF
--- a/Omada Beta/CHANGELOG.md
+++ b/Omada Beta/CHANGELOG.md
@@ -1,9 +1,11 @@
 # Changelog
 
+## 5.13.30 - 2023-03-27
+
+- Support for using the SSL certificate from Home Assistant in Omada
 
 ## 5.13.3 - 2023-08-31
--Version bump to latest Omada Beta
-
+- Version bump to latest Omada Beta
 
 ## 5.9.3 - 2023-08-31
 -Fix for the healthcheck Thanks nathanielks!

--- a/Omada Beta/config.yaml
+++ b/Omada Beta/config.yaml
@@ -1,6 +1,6 @@
 ---
 name: Omada Controller Beta
-version: 5.13.3
+version: 5.13.30
 slug: omada_controller
 description: TP-Link Omada Controller software
 webui: https://[HOST]:[PORT:8043]

--- a/Omada Beta/config.yaml
+++ b/Omada Beta/config.yaml
@@ -10,20 +10,30 @@ arch:
   - amd64
 init: false
 url: https://github.com/jkunczik/home-assistant-omada
+map:
+  - ssl
+options:
+  enable_hass_ssl: false
+  certfile: /ssl/fullchain.pem
+  keyfile: /ssl/privkey.pem
+schema:
+  enable_hass_ssl: bool
+  certfile: str
+  keyfile: str
 ports:
-    8088/tcp: 8088
-    8043/tcp: 8043
-    8843/tcp: 8843
-    29810/tcp: 29810
-    29810/udp: 29810
-    29811/tcp: 29811
-    29811/udp: 29811
-    29812/tcp: 29812
-    29812/udp: 29812
-    29813/tcp: 29813
-    29813/udp: 29813
-    29814/tcp: 29814
-    29815/tcp: 29815
-    29815/udp: 29815
-    29816/tcp: 29816
-    29816/udp: 29816
+  8088/tcp: 8088
+  8043/tcp: 8043
+  8843/tcp: 8843
+  29810/tcp: 29810
+  29810/udp: 29810
+  29811/tcp: 29811
+  29811/udp: 29811
+  29812/tcp: 29812
+  29812/udp: 29812
+  29813/tcp: 29813
+  29813/udp: 29813
+  29814/tcp: 29814
+  29815/tcp: 29815
+  29815/udp: 29815
+  29816/tcp: 29816
+  29816/udp: 29816

--- a/Omada Beta/entrypoint-5.x.sh
+++ b/Omada Beta/entrypoint-5.x.sh
@@ -29,17 +29,17 @@ if bashio::config.true 'enable_hass_ssl'; then
 fi
 
 # validate user/group exist with correct UID/GID
-echo "INFO: Validating user/group (omada:omada) exists with correct UID/GID (${PUID}:${PGID})"
+bashio::log.info "Validating user/group (omada:omada) exists with correct UID/GID (${PUID}:${PGID})"
 
 # check to see if group exists; if not, create it
 if grep -q -E "^omada:" /etc/group > /dev/null 2>&1
 then
   # exiting group found; also make sure the omada user matches the GID
-  echo "INFO: Group (omada) exists; skipping creation"
+  bashio::log.info "Group (omada) exists; skipping creation"
   EXISTING_GID="$(id -g omada)"
   if [ "${EXISTING_GID}" != "${PGID}" ]
   then
-    echo "ERROR: Group (omada) has an unexpected GID; was expecting '${PGID}' but found '${EXISTING_GID}'!"
+    bashio::log.error "Group (omada) has an unexpected GID; was expecting '${PGID}' but found '${EXISTING_GID}'!"
     exit 1
   fi
 else
@@ -48,11 +48,11 @@ else
   then
     # group ID exists but has a different group name
     EXISTING_GROUP="$(grep ":${PGID}:" /etc/group | awk -F ':' '{print $1}')"
-    echo "INFO: Group (omada) already exists with a different name; renaming '${EXISTING_GROUP}' to 'omada'"
+    bashio::log.info "Group (omada) already exists with a different name; renaming '${EXISTING_GROUP}' to 'omada'"
     groupmod -n omada "${EXISTING_GROUP}"
   else
     # create the group
-    echo "INFO: Group (omada) doesn't exist; creating"
+    bashio::log.info "Group (omada) doesn't exist; creating"
     groupadd -g "${PGID}" omada
   fi
 fi
@@ -64,11 +64,11 @@ chown -R 508:508 "/data"
 if id -u omada > /dev/null 2>&1
 then
   # exiting user found; also make sure the omada user matches the UID
-  echo "INFO: User (omada) exists; skipping creation"
+  bashio::log.info "User (omada) exists; skipping creation"
   EXISTING_UID="$(id -u omada)"
   if [ "${EXISTING_UID}" != "${PUID}" ]
   then
-    echo "ERROR: User (omada) has an unexpected UID; was expecting '${PUID}' but found '${EXISTING_UID}'!"
+    bashio::log.error "User (omada) has an unexpected UID; was expecting '${PUID}' but found '${EXISTING_UID}'!"
     exit 1
   fi
 else
@@ -77,34 +77,34 @@ else
   then
     # user ID exists but has a different user name
     EXISTING_USER="$(grep ":${PUID}:" /etc/passwd | awk -F ':' '{print $1}')"
-    echo "INFO: User (omada) already exists with a different name; renaming '${EXISTING_USER}' to 'omada'"
+    bashio::log.info "User (omada) already exists with a different name; renaming '${EXISTING_USER}' to 'omada'"
     usermod -g "${PGID}" -d "${OMADA_DIR}/data" -l omada -s /bin/sh -c "" "${EXISTING_USER}"
   else
     # create the user
-    echo "INFO: User (omada) doesn't exist; creating"
+    bashio::log.info "User (omada) doesn't exist; creating"
     useradd -u "${PUID}" -g "${PGID}" -d "${OMADA_DIR}/data" -s /bin/sh -c "" omada
   fi
 fi
 
 # set default time zone and notify user of time zone
-echo "INFO: Time zone set to '${TZ}'"
+bashio::log.info "Time zone set to '${TZ}'"
 
 # append smallfiles if set to true
 if [ "${SMALL_FILES}" = "true" ]
 then
-  echo "WARN: smallfiles was passed but is not supported in >= 4.1 with the WiredTiger engine in use by MongoDB"
-  echo "INFO: Skipping setting smallfiles option"
+  bashio::log.warning "smallfiles was passed but is not supported in >= 4.1 with the WiredTiger engine in use by MongoDB"
+  bashio::log.info "Skipping setting smallfiles option"
 fi
 
 set_port_property() {
   # check to see if we are trying to bind to privileged port
   if [ "${3}" -lt "1024" ] && [ "$(cat /proc/sys/net/ipv4/ip_unprivileged_port_start)" = "1024" ]
   then
-    echo "ERROR: Unable to set '${1}' to ${3}; 'ip_unprivileged_port_start' has not been set.  See https://github.com/mbentley/docker-omada-controller#unprivileged-ports"
+    bashio::log.error "Unable to set '${1}' to ${3}; 'ip_unprivileged_port_start' has not been set.  See https://github.com/mbentley/docker-omada-controller#unprivileged-ports"
     exit 1
   fi
 
-  echo "INFO: Setting '${1}' to ${3} in omada.properties"
+  bashio::log.info "Setting '${1}' to ${3} in omada.properties"
   sed -i "s/^${1}=${2}$/${1}=${3}/g" "${OMADA_DIR}/properties/omada.properties"
 }
 
@@ -136,7 +136,7 @@ fi
 if [ ! -d "${OMADA_DIR}/data/html" ] && [ -f "${OMADA_DIR}/data-html.tar.gz" ]
 then
   # missing directory; extract from original
-  echo "INFO: Report HTML directory missing; extracting backup to '${OMADA_DIR}/data/html'"
+  bashio::log.info "Report HTML directory missing; extracting backup to '${OMADA_DIR}/data/html'"
   tar zxvf "${OMADA_DIR}/data-html.tar.gz" -C "${OMADA_DIR}/data"
   chown -R omada:omada "${OMADA_DIR}/data/html"
 fi
@@ -145,7 +145,7 @@ fi
 if [ ! -d "${OMADA_DIR}/data/pdf" ]
 then
   # missing directory; extract from original
-  echo "INFO: Report PDF directory missing; creating '${OMADA_DIR}/data/pdf'"
+  bashio::log.info "Report PDF directory missing; creating '${OMADA_DIR}/data/pdf'"
   mkdir "${OMADA_DIR}/data/pdf"
   chown -R omada:omada "${OMADA_DIR}/data/pdf"
 fi
@@ -159,7 +159,7 @@ do
   if [ "${OWNER}" != "${PUID}" ] || [ "${GROUP}" != "${PGID}" ]
   then
     # notify user that uid:gid are not correct and fix them
-    echo "WARN: Ownership not set correctly on '${OMADA_DIR}/${DIR}'; setting correct ownership (omada:omada)"
+    bashio::log.warning "Ownership not set correctly on '${OMADA_DIR}/${DIR}'; setting correct ownership (omada:omada)"
     chown -R omada:omada "${OMADA_DIR}/${DIR}"
   fi
 done
@@ -168,17 +168,17 @@ done
 TMP_PERMISSIONS="$(stat -c '%a' /tmp)"
 if [ "${TMP_PERMISSIONS}" != "1777" ]
 then
-  echo "WARN: Permissions are not set correctly on '/tmp' (${TMP_PERMISSIONS}); setting correct permissions (1777)"
+  bashio::log.warning "Permissions are not set correctly on '/tmp' (${TMP_PERMISSIONS}); setting correct permissions (1777)"
   chmod -v 1777 /tmp
 fi
 
 # check to see if there is a db directory; create it if it is missing
 if [ ! -d "${OMADA_DIR}/data/db" ]
 then
-  echo "INFO: Database directory missing; creating '${OMADA_DIR}/data/db'"
+  bashio::log.info "Database directory missing; creating '${OMADA_DIR}/data/db'"
   mkdir "${OMADA_DIR}/data/db"
   chown omada:omada "${OMADA_DIR}/data/db"
-  echo "done"
+  bashio::log.info "done"
 fi
 
 # Import a cert from a possibly mounted secret or file
@@ -190,13 +190,13 @@ then
     # check to see if the KEYSTORE_DIR exists (it won't on upgrade)
     if [ ! -d "${KEYSTORE_DIR}" ]
     then
-      echo "INFO: Creating keystore directory (${KEYSTORE_DIR})"
+      bashio::log.info "Creating keystore directory (${KEYSTORE_DIR})"
       mkdir "${KEYSTORE_DIR}"
-      echo "INFO: Setting permissions on ${KEYSTORE_DIR}"
+      bashio::log.info "Setting permissions on ${KEYSTORE_DIR}"
       chown omada:omada "${KEYSTORE_DIR}"
   fi
 
-  echo "INFO: Importing certificate and key"
+  bashio::log.info "Importing certificate and key"
   # delete the existing keystore
   rm -f "${KEYSTORE_DIR}/eap.keystore"
 
@@ -218,14 +218,14 @@ fi
 if [ "${TLS_1_11_ENABLED}" = "true" ]
 then
     # not running openjdk8 or openjdk17
-    echo "WARN: Unable to re-enable TLS 1.0 & 1.1; unable to detect openjdk version"
+    bashio::log.warning "Unable to re-enable TLS 1.0 & 1.1; unable to detect openjdk version"
 fi
 
 # see if any of these files exist; if so, do not start as they are from older versions
 if [ -f "${OMADA_DIR}/data/db/tpeap.0" ] || [ -f "${OMADA_DIR}/data/db/tpeap.1" ] || [ -f "${OMADA_DIR}/data/db/tpeap.ns" ]
 then
-  echo "ERROR: The data volume mounted to ${OMADA_DIR}/data appears to have data from a previous version!"
-  echo "  Follow the upgrade instructions at https://github.com/mbentley/docker-omada-controller#upgrading-to-41"
+  bashio::log.error "The data volume mounted to ${OMADA_DIR}/data appears to have data from a previous version!"
+  bashio::log.error "  Follow the upgrade instructions at https://github.com/mbentley/docker-omada-controller#upgrading-to-41"
   exit 1
 fi
 
@@ -240,7 +240,7 @@ else
 fi
 
 
-echo "INFO: Starting Omada Controller as user omada"
+bashio::log.info "Starting Omada Controller as user omada"
 
 # tail the omada logs if set to true
 if [ "${SHOW_SERVER_LOGS}" = "true" ]

--- a/Omada Beta/install.sh
+++ b/Omada Beta/install.sh
@@ -26,6 +26,8 @@ PKGS=(
   openjdk-17-jre-headless
   tzdata
   wget
+  curl
+  jq
 )
 
 case "${ARCH}" in
@@ -49,6 +51,14 @@ echo "**** Install Dependencies ****"
 export DEBIAN_FRONTEND=noninteractive
 apt-get update
 apt-get install --no-install-recommends -y "${PKGS[@]}"
+
+BASHIO_VERSION="0.16.2"
+echo "**** Install BashIO ${BASHIO_VERSION}, for parsing HASS AddOn options ****"
+mkdir -p /usr/src/bashio
+curl -L -f -s "https://github.com/hassio-addons/bashio/archive/v${BASHIO_VERSION}.tar.gz" \
+  | tar -xzf - --strip 1 -C /usr/src/bashio
+mv /usr/src/bashio/lib /usr/lib/bashio
+ln -s /usr/lib/bashio/bashio /usr/bin/bashio
 
 echo "**** Download Omada Controller ****"
 cd /tmp

--- a/Omada Beta/translations/en.yaml
+++ b/Omada Beta/translations/en.yaml
@@ -1,0 +1,11 @@
+---
+configuration:
+  enable_hass_ssl:
+    name: Enable Home Assistant SSL
+    description: This can be used to enable your own Home Assistant certificate.
+  keyfile:
+    name: Private Key File
+    description: Path to the Private Key File.
+  certfile:
+    name: Certificate File
+    description: Path to the Certificate File.

--- a/Omada Stable/CHANGELOG.md
+++ b/Omada Stable/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 5.13.1 - 2024-03-27
+
+- Support for using the SSL certificate from Home Assistant in Omada
+
 ## 5.9.3 - 2023-08-31
 -Fix for the healthcheck Thanks nathanielks!
 

--- a/Omada Stable/config.yaml
+++ b/Omada Stable/config.yaml
@@ -12,23 +12,28 @@ init: false
 url: https://github.com/jkunczik/home-assistant-omada
 map:
   - ssl
-environment:
-  SSL_CERT: "/ssl/fullchain.pem"
-  SSL_KEY: "/ssl/privkey.pem"
+options:
+  enable_hass_ssl: false
+  certfile: /ssl/fullchain.pem
+  keyfile: /ssl/privkey.pem
+schema:
+  enable_hass_ssl: bool
+  certfile: str
+  keyfile: str
 ports:
-    8088/tcp: 8088
-    8043/tcp: 8043
-    8843/tcp: 8843
-    29810/tcp: 29810
-    29810/udp: 29810
-    29811/tcp: 29811
-    29811/udp: 29811
-    29812/tcp: 29812
-    29812/udp: 29812
-    29813/tcp: 29813
-    29813/udp: 29813
-    29814/tcp: 29814
-    29815/tcp: 29815
-    29815/udp: 29815
-    29816/tcp: 29816
-    29816/udp: 29816
+  8088/tcp: 8088
+  8043/tcp: 8043
+  8843/tcp: 8843
+  29810/tcp: 29810
+  29810/udp: 29810
+  29811/tcp: 29811
+  29811/udp: 29811
+  29812/tcp: 29812
+  29812/udp: 29812
+  29813/tcp: 29813
+  29813/udp: 29813
+  29814/tcp: 29814
+  29815/tcp: 29815
+  29815/udp: 29815
+  29816/tcp: 29816
+  29816/udp: 29816

--- a/Omada Stable/config.yaml
+++ b/Omada Stable/config.yaml
@@ -1,6 +1,6 @@
 ---
 name: Omada Controller Stable
-version: 5.11.1
+version: 5.13.1
 slug: omada_controller_stable
 description: TP-Link Omada Controller software
 webui: https://[HOST]:[PORT:8043]

--- a/Omada Stable/config.yaml
+++ b/Omada Stable/config.yaml
@@ -10,6 +10,11 @@ arch:
   - amd64
 init: false
 url: https://github.com/jkunczik/home-assistant-omada
+map:
+  - ssl
+environment:
+  SSL_CERT: "/ssl/fullchain.pem"
+  SSL_KEY: "/ssl/privkey.pem"
 ports:
     8088/tcp: 8088
     8043/tcp: 8043

--- a/Omada Stable/entrypoint-5.x.sh
+++ b/Omada Stable/entrypoint-5.x.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bashio
 
 set -e
 
@@ -19,6 +19,14 @@ TLS_1_11_ENABLED="${TLS_1_11_ENABLED:-false}"
 OMADA_DIR="/opt/tplink/EAPController"
 PUID="${PUID:-508}"
 PGID="${PGID:-508}"
+
+if bashio::config.true 'enable_hass_ssl'; then
+  bashio::log.info "Use SSL from Home Assistant"
+  SSL_CERT=$(bashio::config 'certfile')
+  bashio::log.info "SSL certificate: ${SSL_CERT}"
+  SSL_KEY=$(bashio::config 'keyfile')
+  bashio::log.info "SSL private key: ${SSL_KEY}"
+fi
 
 # validate user/group exist with correct UID/GID
 echo "INFO: Validating user/group (omada:omada) exists with correct UID/GID (${PUID}:${PGID})"

--- a/Omada Stable/entrypoint-5.x.sh
+++ b/Omada Stable/entrypoint-5.x.sh
@@ -12,8 +12,8 @@ PORTAL_HTTP_PORT="${PORTAL_HTTP_PORT:-8088}"
 PORTAL_HTTPS_PORT="${PORTAL_HTTPS_PORT:-8843}"
 SHOW_SERVER_LOGS="${SHOW_SERVER_LOGS:-true}"
 SHOW_MONGODB_LOGS="${SHOW_MONGODB_LOGS:-false}"
-SSL_CERT_NAME="${SSL_CERT_NAME:-tls.crt}"
-SSL_KEY_NAME="${SSL_KEY_NAME:-tls.key}"
+SSL_CERT="${SSL_CERT:-tls.crt}"
+SSL_KEY="${SSL_KEY:-tls.key}"
 TLS_1_11_ENABLED="${TLS_1_11_ENABLED:-false}"
 # default /opt/tplink/EAPController
 OMADA_DIR="/opt/tplink/EAPController"
@@ -173,12 +173,9 @@ then
   echo "done"
 fi
 
-# Import a cert from a possibly mounted secret or file at /cert
-if [ -f "/cert/${SSL_KEY_NAME}" ] && [ -f "/cert/${SSL_CERT_NAME}" ]
+# Import a cert from a possibly mounted secret or file
+if [ -f "${SSL_KEY}" ] && [ -f "${SSL_CERT}" ]
 then
-  # see where the keystore directory is; check for old location first
-  if [ -d "${OMADA_DIR}/keystore" ]
-  then
     # keystore directory moved to the data directory in 5.3.1
     KEYSTORE_DIR="${OMADA_DIR}/data/keystore"
 
@@ -189,18 +186,17 @@ then
       mkdir "${KEYSTORE_DIR}"
       echo "INFO: Setting permissions on ${KEYSTORE_DIR}"
       chown omada:omada "${KEYSTORE_DIR}"
-    fi
   fi
 
-  echo "INFO: Importing cert from /cert/tls.[key|crt]"
+  echo "INFO: Importing certificate and key"
   # delete the existing keystore
   rm -f "${KEYSTORE_DIR}/eap.keystore"
 
   # example certbot usage: ./certbot-auto certonly --standalone --preferred-challenges http -d mydomain.net
   openssl pkcs12 -export \
-    -inkey "/cert/${SSL_KEY_NAME}" \
-    -in "/cert/${SSL_CERT_NAME}" \
-    -certfile "/cert/${SSL_CERT_NAME}" \
+    -inkey "${SSL_KEY}" \
+    -in "${SSL_CERT}" \
+    -certfile "${SSL_CERT}" \
     -name eap \
     -out "${KEYSTORE_DIR}/eap.keystore" \
     -passout pass:tplink

--- a/Omada Stable/entrypoint-5.x.sh
+++ b/Omada Stable/entrypoint-5.x.sh
@@ -29,17 +29,17 @@ if bashio::config.true 'enable_hass_ssl'; then
 fi
 
 # validate user/group exist with correct UID/GID
-echo "INFO: Validating user/group (omada:omada) exists with correct UID/GID (${PUID}:${PGID})"
+bashio::log.info "Validating user/group (omada:omada) exists with correct UID/GID (${PUID}:${PGID})"
 
 # check to see if group exists; if not, create it
 if grep -q -E "^omada:" /etc/group > /dev/null 2>&1
 then
   # exiting group found; also make sure the omada user matches the GID
-  echo "INFO: Group (omada) exists; skipping creation"
+  bashio::log.info "Group (omada) exists; skipping creation"
   EXISTING_GID="$(id -g omada)"
   if [ "${EXISTING_GID}" != "${PGID}" ]
   then
-    echo "ERROR: Group (omada) has an unexpected GID; was expecting '${PGID}' but found '${EXISTING_GID}'!"
+    bashio::log.error "Group (omada) has an unexpected GID; was expecting '${PGID}' but found '${EXISTING_GID}'!"
     exit 1
   fi
 else
@@ -48,11 +48,11 @@ else
   then
     # group ID exists but has a different group name
     EXISTING_GROUP="$(grep ":${PGID}:" /etc/group | awk -F ':' '{print $1}')"
-    echo "INFO: Group (omada) already exists with a different name; renaming '${EXISTING_GROUP}' to 'omada'"
+    bashio::log.info "Group (omada) already exists with a different name; renaming '${EXISTING_GROUP}' to 'omada'"
     groupmod -n omada "${EXISTING_GROUP}"
   else
     # create the group
-    echo "INFO: Group (omada) doesn't exist; creating"
+    bashio::log.info "Group (omada) doesn't exist; creating"
     groupadd -g "${PGID}" omada
   fi
 fi
@@ -64,11 +64,11 @@ chown -R 508:508 "/data"
 if id -u omada > /dev/null 2>&1
 then
   # exiting user found; also make sure the omada user matches the UID
-  echo "INFO: User (omada) exists; skipping creation"
+  bashio::log.info "User (omada) exists; skipping creation"
   EXISTING_UID="$(id -u omada)"
   if [ "${EXISTING_UID}" != "${PUID}" ]
   then
-    echo "ERROR: User (omada) has an unexpected UID; was expecting '${PUID}' but found '${EXISTING_UID}'!"
+    bashio::log.error "User (omada) has an unexpected UID; was expecting '${PUID}' but found '${EXISTING_UID}'!"
     exit 1
   fi
 else
@@ -77,34 +77,34 @@ else
   then
     # user ID exists but has a different user name
     EXISTING_USER="$(grep ":${PUID}:" /etc/passwd | awk -F ':' '{print $1}')"
-    echo "INFO: User (omada) already exists with a different name; renaming '${EXISTING_USER}' to 'omada'"
+    bashio::log.info "User (omada) already exists with a different name; renaming '${EXISTING_USER}' to 'omada'"
     usermod -g "${PGID}" -d "${OMADA_DIR}/data" -l omada -s /bin/sh -c "" "${EXISTING_USER}"
   else
     # create the user
-    echo "INFO: User (omada) doesn't exist; creating"
+    bashio::log.info "User (omada) doesn't exist; creating"
     useradd -u "${PUID}" -g "${PGID}" -d "${OMADA_DIR}/data" -s /bin/sh -c "" omada
   fi
 fi
 
 # set default time zone and notify user of time zone
-echo "INFO: Time zone set to '${TZ}'"
+bashio::log.info "Time zone set to '${TZ}'"
 
 # append smallfiles if set to true
 if [ "${SMALL_FILES}" = "true" ]
 then
-  echo "WARN: smallfiles was passed but is not supported in >= 4.1 with the WiredTiger engine in use by MongoDB"
-  echo "INFO: Skipping setting smallfiles option"
+  bashio::log.warning "smallfiles was passed but is not supported in >= 4.1 with the WiredTiger engine in use by MongoDB"
+  bashio::log.info "Skipping setting smallfiles option"
 fi
 
 set_port_property() {
   # check to see if we are trying to bind to privileged port
   if [ "${3}" -lt "1024" ] && [ "$(cat /proc/sys/net/ipv4/ip_unprivileged_port_start)" = "1024" ]
   then
-    echo "ERROR: Unable to set '${1}' to ${3}; 'ip_unprivileged_port_start' has not been set.  See https://github.com/mbentley/docker-omada-controller#unprivileged-ports"
+    bashio::log.error "Unable to set '${1}' to ${3}; 'ip_unprivileged_port_start' has not been set.  See https://github.com/mbentley/docker-omada-controller#unprivileged-ports"
     exit 1
   fi
 
-  echo "INFO: Setting '${1}' to ${3} in omada.properties"
+  bashio::log.info "Setting '${1}' to ${3} in omada.properties"
   sed -i "s/^${1}=${2}$/${1}=${3}/g" "${OMADA_DIR}/properties/omada.properties"
 }
 
@@ -136,7 +136,7 @@ fi
 if [ ! -d "${OMADA_DIR}/data/html" ] && [ -f "${OMADA_DIR}/data-html.tar.gz" ]
 then
   # missing directory; extract from original
-  echo "INFO: Report HTML directory missing; extracting backup to '${OMADA_DIR}/data/html'"
+  bashio::log.info "Report HTML directory missing; extracting backup to '${OMADA_DIR}/data/html'"
   tar zxvf "${OMADA_DIR}/data-html.tar.gz" -C "${OMADA_DIR}/data"
   chown -R omada:omada "${OMADA_DIR}/data/html"
 fi
@@ -145,7 +145,7 @@ fi
 if [ ! -d "${OMADA_DIR}/data/pdf" ]
 then
   # missing directory; extract from original
-  echo "INFO: Report PDF directory missing; creating '${OMADA_DIR}/data/pdf'"
+  bashio::log.info "Report PDF directory missing; creating '${OMADA_DIR}/data/pdf'"
   mkdir "${OMADA_DIR}/data/pdf"
   chown -R omada:omada "${OMADA_DIR}/data/pdf"
 fi
@@ -159,7 +159,7 @@ do
   if [ "${OWNER}" != "${PUID}" ] || [ "${GROUP}" != "${PGID}" ]
   then
     # notify user that uid:gid are not correct and fix them
-    echo "WARN: Ownership not set correctly on '${OMADA_DIR}/${DIR}'; setting correct ownership (omada:omada)"
+    bashio::log.warning "Ownership not set correctly on '${OMADA_DIR}/${DIR}'; setting correct ownership (omada:omada)"
     chown -R omada:omada "${OMADA_DIR}/${DIR}"
   fi
 done
@@ -168,17 +168,17 @@ done
 TMP_PERMISSIONS="$(stat -c '%a' /tmp)"
 if [ "${TMP_PERMISSIONS}" != "1777" ]
 then
-  echo "WARN: Permissions are not set correctly on '/tmp' (${TMP_PERMISSIONS}); setting correct permissions (1777)"
+  bashio::log.warning "Permissions are not set correctly on '/tmp' (${TMP_PERMISSIONS}); setting correct permissions (1777)"
   chmod -v 1777 /tmp
 fi
 
 # check to see if there is a db directory; create it if it is missing
 if [ ! -d "${OMADA_DIR}/data/db" ]
 then
-  echo "INFO: Database directory missing; creating '${OMADA_DIR}/data/db'"
+  bashio::log.info "Database directory missing; creating '${OMADA_DIR}/data/db'"
   mkdir "${OMADA_DIR}/data/db"
   chown omada:omada "${OMADA_DIR}/data/db"
-  echo "done"
+  bashio::log.info "done"
 fi
 
 # Import a cert from a possibly mounted secret or file
@@ -190,13 +190,13 @@ then
     # check to see if the KEYSTORE_DIR exists (it won't on upgrade)
     if [ ! -d "${KEYSTORE_DIR}" ]
     then
-      echo "INFO: Creating keystore directory (${KEYSTORE_DIR})"
+      bashio::log.info "Creating keystore directory (${KEYSTORE_DIR})"
       mkdir "${KEYSTORE_DIR}"
-      echo "INFO: Setting permissions on ${KEYSTORE_DIR}"
+      bashio::log.info "Setting permissions on ${KEYSTORE_DIR}"
       chown omada:omada "${KEYSTORE_DIR}"
   fi
 
-  echo "INFO: Importing certificate and key"
+  bashio::log.info "Importing certificate and key"
   # delete the existing keystore
   rm -f "${KEYSTORE_DIR}/eap.keystore"
 
@@ -218,14 +218,14 @@ fi
 if [ "${TLS_1_11_ENABLED}" = "true" ]
 then
     # not running openjdk8 or openjdk17
-    echo "WARN: Unable to re-enable TLS 1.0 & 1.1; unable to detect openjdk version"
+    bashio::log.warning "Unable to re-enable TLS 1.0 & 1.1; unable to detect openjdk version"
 fi
 
 # see if any of these files exist; if so, do not start as they are from older versions
 if [ -f "${OMADA_DIR}/data/db/tpeap.0" ] || [ -f "${OMADA_DIR}/data/db/tpeap.1" ] || [ -f "${OMADA_DIR}/data/db/tpeap.ns" ]
 then
-  echo "ERROR: The data volume mounted to ${OMADA_DIR}/data appears to have data from a previous version!"
-  echo "  Follow the upgrade instructions at https://github.com/mbentley/docker-omada-controller#upgrading-to-41"
+  bashio::log.error "The data volume mounted to ${OMADA_DIR}/data appears to have data from a previous version!"
+  bashio::log.error "  Follow the upgrade instructions at https://github.com/mbentley/docker-omada-controller#upgrading-to-41"
   exit 1
 fi
 
@@ -240,7 +240,7 @@ else
 fi
 
 
-echo "INFO: Starting Omada Controller as user omada"
+bashio::log.info "Starting Omada Controller as user omada"
 
 # tail the omada logs if set to true
 if [ "${SHOW_SERVER_LOGS}" = "true" ]

--- a/Omada Stable/install.sh
+++ b/Omada Stable/install.sh
@@ -26,6 +26,8 @@ PKGS=(
   openjdk-17-jre-headless
   tzdata
   wget
+  curl
+  jq
 )
 
 case "${ARCH}" in
@@ -49,6 +51,14 @@ echo "**** Install Dependencies ****"
 export DEBIAN_FRONTEND=noninteractive
 apt-get update
 apt-get install --no-install-recommends -y "${PKGS[@]}"
+
+BASHIO_VERSION="0.16.2"
+echo "**** Install BashIO ${BASHIO_VERSION}, for parsing HASS AddOn options ****"
+mkdir -p /usr/src/bashio
+curl -L -f -s "https://github.com/hassio-addons/bashio/archive/v${BASHIO_VERSION}.tar.gz" \
+  | tar -xzf - --strip 1 -C /usr/src/bashio
+mv /usr/src/bashio/lib /usr/lib/bashio
+ln -s /usr/lib/bashio/bashio /usr/bin/bashio
 
 echo "**** Download Omada Controller ****"
 cd /tmp

--- a/Omada Stable/translations/en.yaml
+++ b/Omada Stable/translations/en.yaml
@@ -1,0 +1,11 @@
+---
+configuration:
+  enable_hass_ssl:
+    name: Enable Home Assistant SSL
+    description: This can be used to enable your own Home Assistant certificate.
+  keyfile:
+    name: Private Key File
+    description: Path to the Private Key File.
+  certfile:
+    name: Certificate File
+    description: Path to the Certificate File.

--- a/README.md
+++ b/README.md
@@ -1,22 +1,38 @@
 # Home Assistant Omada Add-On
+
 This add-on brings the Omada Controller directly into Home Assistant running on an 64 bit ARM or a x64 processor.
 
 There exist two Add-On-Versions:
+
 - Omada Stable
 - Omada Beta
 
 Omada Stable is created from Omada Beta (both in this repository), as soon as the beta add-on is updated to the latest
 stable upstream version. Omada Beta should also be fairly stable, because the Add-On is mostly consistent with the already tested [docker-omada-cotroller](https://github.com/mbentley/docker-omada-controller), but might contain some Home-Assistant related inconsistencies or bugs.
 
-# Installation
+## Installation
+
 Installing third-party repositories:
+
 1. Go to home assistant -> settings -> addons -> addon store
 2. Click the hamburger menu (The three dots in the top right corner)
 3. Click repositories
 4. At the bottom there should be a space to paste the GitHub link: https://github.com/jkunczik/home-assistant-omada
 5. You might have to refresh the page, but it should show up in the addon store under "Home Assistant Omada"
 
-# Contribution 
+## Options
+
+If you would like to use your own SSL certificate configured for Home Assistant with this Omada Add-On,
+it can be enabled in the configuration options.
+Set `Enable Home Assistant SSL` to `true`, and enter the full path for:
+
+- `Certificate file`
+- `Private key`
+
+The default paths are compatible with the `Letsencrypt` Add-On.
+
+## Contribution
+
 This add-on is a fork of Matt Bentleys [docker-omada-cotroller](https://github.com/mbentley/docker-omada-controller) and jkunczik [home-assistant-omada](https://github.com/jkunczik/home-assistant-omada) would not have been possible without thier excellent work. Other than in the original docker omada controller, this add-on stores all persistent data in the /data directory, so that it is compatible with Home assistant. This Add-On would not be possible without the effort of other people. Pull requests for version
 updates or new features are always more than welcome. Special thanks goes to DraTrav for pushing this Add-On forward!
 


### PR DESCRIPTION
Added the implementation to run the AddOn Omada Controller with the certificate from the Home Assistant installation.

- Added BashIO from other HASS base images, so the options from the config.yaml can easily be parsed in the entrypoint.sh script.
  - This required also the extra `jq` (json) and `curl` packages.
- Also use BashIO for logging. Looks better inside Home Assistant, and is now available anyway.
- The certificate, from LetsEncrypt AddOn can now be set to be used with the Omada Controller in entrypoint.sh
- Updated README with the extra options. 