### PR TITLE
Restore backup old file structure

### DIFF
--- a/Omada Beta/CHANGELOG.md
+++ b/Omada Beta/CHANGELOG.md
@@ -4,12 +4,13 @@
 
 - Upgrade to 5.14.32.3
 - Fix SSL configuration
+- Fix restoring backup old file structure. Manual backup no longer needed.
 
 ## 5.14.32.2 - 2024-09-5
-### WARNING BREAKIN CHANGES PLEASE BACKUP YOUR OMADA CONFIGURATION TO RESTORE IT AFTER THIS UPDATE
+
 - Updated to the upstream version 5.14.32.2
 - fully merged all files (`install.sh`, `entrypoint.sh`, `Dockerfile`)
-- only storing essential data (`data` and `lgos`) in the persistent `/data` volume
+- only storing essential data (`data` and `logs`) in the persistent `/data` volume
 
 ## 5.14.7 - 2024-09-5
 ### Changed

--- a/Omada Beta/entrypoint.sh
+++ b/Omada Beta/entrypoint.sh
@@ -8,7 +8,22 @@
 bashio::log.info "Create 'logs' directory inside persistent /data volume, if it doesn't exist."
 mkdir -p "/data/logs"
 
-[ ! -d /data/data ] && bashio::log.info "/data/data created from backup" && cp -r /opt/tplink/EAPController/data_backup /data/data
+if [ ! -d /data/data ]; then
+  bashio::log.info "/data/data created from docker image backup" && cp -r /opt/tplink/EAPController/data_backup /data/data
+
+  # Check if old directory structure is in place (/data) and copy to (/data/data)
+  # This can be removed in the future when everyone has upgraded
+  directories=(db keystore pdf)
+  for dir in "${directories[@]}"; do
+    if [ -d "/data/$dir" ]; then
+      cp -r /data/$dir "/data/data/"
+      rm -rf /data/$dir
+      bashio::log.info "Migrate from old Add-On file structure. Copied /data/$dir to /data/data/$dir"
+    else
+      bashio::log.info "Already in new file structure. /data/$dir does not exist, skipping."
+    fi
+  done
+fi
 
 # set permissions on /data directory for home assistant persistence
 chown -R 508:508 "/data"


### PR DESCRIPTION
The old path for the data was in `/data`. This has been changed to `/data/data`. This new structure is better, it has a better seperation between Omada files and HASS Add-On files. I fixed restoring the backup from the old file structure.

@DraTrav Can you build new docker image, and merge?

Fixed #42 
