### PR TITLE
Feature/add extra version check for pull requests

### DIFF
--- a/.github/workflows/check-omada-versions.yaml
+++ b/.github/workflows/check-omada-versions.yaml
@@ -13,6 +13,11 @@ jobs:
         target: ["Beta", "Stable", "Dev"]
 
     steps:
+      - name: Checkout the code
+        uses: actions/checkout@v4
+        with:
+          submodules: true
+
       - name: Extract Version and Set Tag
         id: extract_version
         run: |

--- a/.github/workflows/check-omada-versions.yaml
+++ b/.github/workflows/check-omada-versions.yaml
@@ -1,0 +1,26 @@
+name: Check Omada Versions on Pull Request
+
+on:
+  pull_request:
+    branches:
+      - master
+
+jobs:
+  check-omada-versions:
+    runs-on: ubuntu-24.04
+    strategy:
+      matrix:
+        target: ["Beta", "Stable", "Dev"]
+
+    steps:
+      - name: Extract Version and Set Tag
+        id: extract_version
+        run: |
+          VERSION=$(yq '.version' "Omada ${{ matrix.target }}/config.yaml")
+          echo "VERSION=$VERSION" >> $GITHUB_ENV
+          echo "Target ${{ matrix.target }} VERSION: $VERSION"
+
+      - name: Check Omada Version Availability
+        uses: ./.github/actions/version-checks
+        with:
+          version: "${{ env.VERSION }}"


### PR DESCRIPTION
- This checks if the version specified in the config.yaml is available for every target.
It is important to check this before the PR is merged to`master`, so the pipeline won't fail after the PR has been merged.
  - I tried to build and tag temporary images for PR's (to make sure everything is ok before the merge), but GitHub prohibits using secrets in a PR pipeline (Docker Hub credentials). It is hard to work around this and also discouraged.
  - The pipeline always builds the docker images for **Dev** without publishing. So as long as that works, and the versions for **Beta** and **Stable** are checked, everything should be ok for the merge.