### PR TITLE
Feature/update mbentley submodule

### DIFF
--- a/Omada Beta/CHANGELOG.md
+++ b/Omada Beta/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## beta-5.15.24.17-ha1 2025-06-19
+
+- Updated mbentley submodule
+
 ## beta-5.15.24.17 2025-06-19
 
 - Updated to Omada release candidate - version 5.15.24.17

--- a/Omada Beta/config.yaml
+++ b/Omada Beta/config.yaml
@@ -1,7 +1,7 @@
 ---
 name: Omada Controller Beta
 image: jeruntu/home-assistant-omada-beta
-version: 5.15.24.17
+version: 5.15.24.17-ha1
 slug: omada_controller_beta
 description: TP-Link Omada Controller software
 webui: https://[HOST]:[PORT:8043]

--- a/Omada Dev/entrypoint.sh
+++ b/Omada Dev/entrypoint.sh
@@ -51,6 +51,9 @@ if bashio::config.true 'enable_workaround_509'; then
   WORKAROUND_509=true
 fi
 
+# Don't use rootless mode for this Add-On
+ROOTLESS=false
+
 # ======================================
 # mbentley
 # ======================================


### PR DESCRIPTION
- Updated the submodule mbentley to latest on master
- Made this entrypoint work again with mbentley by disabling the rootless support.
- Release new beta version with these changes, Omada version stays the same: 5.15.24.17-ha1