### PR TITLE
Add privileged settings to config.yaml

### DIFF
--- a/Omada Stable v6/config.yaml
+++ b/Omada Stable v6/config.yaml
@@ -29,3 +29,5 @@ schema:
   show_mongodb_logs: bool
   show_server_logs: bool
 host_network: true
+privileged:
+  - SYS_RESOURCE

--- a/Omada Stable v6/config.yaml
+++ b/Omada Stable v6/config.yaml
@@ -1,7 +1,7 @@
 ---
 name: Omada Controller Stable v6
 image: jeruntu/home-assistant-omada-stable-v6
-version: 6.2.10.17
+version: 6.2.10.18
 slug: omada_controller_stable_v6
 description: TP-Link Omada Controller software
 webui: https://[HOST]:[PORT:8043]


### PR DESCRIPTION
Title:
fix: add SYS_RESOURCE privilege to expose Protection Mode toggle for ARM64 compatibility
Resolves: #112 

Description:
🛑 The Problem
When running this add-on on modern 64-bit ARM hardware (specifically the Raspberry Pi 5) under Home Assistant OS, the internal MongoDB instance enters an instant, fatal crash loop. The logs repeatedly throw the following error:

Plaintext
```
src/third_party/tcmalloc/dist/tcmalloc/system-alloc.cc:755] MmapAligned() failed - unable to allocate with tag...
CHECK in Alloc: FATAL ERROR: Out of memory trying to allocate internal tcmalloc data...
```

🔍 Root Cause
Modern versions of MongoDB bundled with Omada v6 utilize Google's tcmalloc memory allocator. On aarch64 architectures, tcmalloc relies heavily on standard memory address layout hints and allocation system calls (mmap) to initialize.

Because this add-on requires host_network: true, the Home Assistant Supervisor automatically forces maximum AppArmor security restrictions and completely hides the user-facing "Protection mode" toggle switch. Under this strict confinement, the Pi 5 kernel blocks the required memory placement checks, triggering an instant database failure.

The Solution
This PR adds the SYS_RESOURCE capability under the privileged key in config.yaml.

YAML
```
host_network: true
privileged:
  - SYS_RESOURCE
```
Why this works: Defining a capability under privileged signals to the Home Assistant Supervisor that the container requires specialized resource access. This explicitly forces the Supervisor to expose the "Protection mode" toggle switch on the add-on's UI Info tab.

Least Privilege Adherence: Instead of requesting full host root access via privileged: true or SYS_ADMIN (which would pose a massive security risk), SYS_RESOURCE is the absolute minimal, isolated capability required to let the Supervisor unlock the UI toggle.

🚀 Impact
Standard / x86_64 Users: No change. The add-on remains 100% hardened and sandboxed out of the box.

Raspberry Pi 5 Users: Users can now natively go to the add-on's Info tab, toggle Protection mode OFF, and run Omada v6 successfully without needing to use unsupported host-level CLI overrides (ha addons options).