### PR TITLE
Update Omada Stable v6 (HA OS) to v6.2.14.11

### DIFF
--- a/Omada Stable v6 (HA OS)/CHANGELOG.md
+++ b/Omada Stable v6 (HA OS)/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Version release 6.2.14.11 2026-07-20
+
+- Updated to Omada version 6.2.14.11
+
 ## 6.2.10.17
 
 - Initial release of the HA OS variant.

--- a/Omada Stable v6 (HA OS)/config.yaml
+++ b/Omada Stable v6 (HA OS)/config.yaml
@@ -1,7 +1,7 @@
 ---
 name: Omada Controller Stable v6 (HA OS)
 image: jeruntu/home-assistant-omada-stable-v6-haos
-version: 6.2.10.17
+version: 6.2.14.11
 slug: omada_controller_stable_v6_haos
 description: TP-Link Omada Controller software for Raspberry Pi 5 on Home Assistant OS
 webui: https://[HOST]:[PORT:8043]


### PR DESCRIPTION
TP-Link released v6.2.14.11 as latest stable version