### PR TITLE
Update beta to 6.3.0.42

### DIFF
--- a/Omada Beta/CHANGELOG.md
+++ b/Omada Beta/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## beta-6.3.0.42 2026-08-06
+
+- Updated to Omada version beta-6.3.0.42
+
 ## beta-6.3.0.36 2026-08-01
 
 - Updated to Omada version beta-6.3.0.36

--- a/Omada Beta/config.yaml
+++ b/Omada Beta/config.yaml
@@ -1,7 +1,7 @@
 ---
 name: Omada Controller Beta
 image: jeruntu/home-assistant-omada-beta
-version: beta-6.3.0.36
+version: beta-6.3.0.42
 slug: omada_controller_beta
 description: TP-Link Omada Controller software
 webui: https://[HOST]:[PORT:8043]


### PR DESCRIPTION
TP-Link released v6.3.0.42 as latest available beta - updating this repo to match latest available beta.