### PR TITLE
Update v6 stable (all variants) to v6.3.0.45

### DIFF
--- a/Omada Stable v6 (HA OS)/CHANGELOG.md
+++ b/Omada Stable v6 (HA OS)/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Version release 6.3.0.45 2026-09-05
+
+- Updated to Omada version 6.3.0.45
+
 ## Version release 6.3.0.44 2026-08-30
 
 - Updated to Omada version 6.3.0.44

--- a/Omada Stable v6 (HA OS)/config.yaml
+++ b/Omada Stable v6 (HA OS)/config.yaml
@@ -1,7 +1,7 @@
 ---
 name: Omada Controller Stable v6 (HA OS)
 image: jeruntu/home-assistant-omada-stable-v6-haos
-version: 6.3.0.44
+version: 6.3.0.45
 slug: omada_controller_stable_v6_haos
 description: TP-Link Omada Controller software for Raspberry Pi 5 on Home Assistant OS
 webui: https://[HOST]:[PORT:8043]

--- a/Omada Stable v6 NO-AVX/CHANGELOG.md
+++ b/Omada Stable v6 NO-AVX/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Version release 6.3.0.45 2026-09-05
+
+- Updated to Omada version 6.3.0.45
+
 ## Version release 6.3.0.44 2026-08-30
 
 - Updated to Omada version 6.3.0.44

--- a/Omada Stable v6 NO-AVX/config.yaml
+++ b/Omada Stable v6 NO-AVX/config.yaml
@@ -1,7 +1,7 @@
 ---
 name: Omada Controller Stable NO-AVX
 image: jeruntu/home-assistant-omada-stable-no-avx
-version: 6.3.0.44
+version: 6.3.0.45
 slug: omada_controller_stable_no_avx
 description: TP-Link Omada Controller software (No AVX support for older CPUs)
 webui: https://[HOST]:[PORT:8043]

--- a/Omada Stable v6/CHANGELOG.md
+++ b/Omada Stable v6/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Version release 6.3.0.45 2026-09-05
+
+- Updated to Omada version 6.3.0.45
+
 ## Version release 6.3.0.44 2026-08-30
 
 - Updated to Omada version 6.3.0.44

--- a/Omada Stable v6/config.yaml
+++ b/Omada Stable v6/config.yaml
@@ -1,7 +1,7 @@
 ---
 name: Omada Controller Stable v6
 image: jeruntu/home-assistant-omada-stable-v6
-version: 6.3.0.44
+version: 6.3.0.45
 slug: omada_controller_stable_v6
 description: TP-Link Omada Controller software
 webui: https://[HOST]:[PORT:8043]


### PR DESCRIPTION
TP-Link released v6.3.0.45 as latest stable release - updating this repo to match latest available version from TP-Link and Matt Bentley.